### PR TITLE
feat: support mount table repartition (with consistency)

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CreateFlag.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CreateFlag.java
@@ -131,7 +131,7 @@ public enum CreateFlag {
     this.mode = mode;
   }
 
-  short getMode() {
+  public short getMode() {
     return mode;
   }
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSMountRepartitionProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSMountRepartitionProtocol.java
@@ -19,10 +19,11 @@ package org.apache.hadoop.hdfs.server.namenode;
 
 import java.io.IOException;
 import org.apache.hadoop.ipc.VersionedProtocol;
-
+import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
 import org.apache.hadoop.hdfs.server.namenode.FsImageProto.MountPartition;
 
 public interface FSMountRepartitionProtocol extends VersionedProtocol {
     public static final long versionID = 1L;
     public void recordMove(byte[] data) throws IOException;
+    public HdfsFileStatus create(byte[] params) throws IOException;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSMountRepartitionProtocolImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSMountRepartitionProtocolImpl.java
@@ -29,8 +29,16 @@ import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.hdfs.DFSUtil;
 
 import org.apache.hadoop.hdfs.server.namenode.FsImageProto.MountPartition;
-
+import org.apache.hadoop.hdfs.server.namenode.FsImageProto.Operation;
+import org.apache.hadoop.hdfs.server.namenode.FsImageProto.CryptoProtocol;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
+import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
+import org.apache.hadoop.fs.permission.PermissionStatus;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.crypto.CryptoProtocolVersion;
+import org.apache.hadoop.fs.CreateFlag;
+
+import java.util.EnumSet;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import com.google.common.base.Preconditions;
@@ -46,6 +54,49 @@ public class FSMountRepartitionProtocolImpl implements FSMountRepartitionProtoco
             e.printStackTrace();
         }
         INodeKeyedObjects.getMoveCache().put(mp.getMountPoint(), mp.getNewUri());
+    }
+
+    @Override
+    public HdfsFileStatus create(byte[] params) throws IOException {
+        Operation.Create op = null;
+        try {
+            op = Operation.Create.parseFrom(params);
+        } catch (InvalidProtocolBufferException e) {
+            e.printStackTrace();
+        }
+        String src = op.getSrc();
+        long permission = op.getPermissions();
+        PermissionStatus permissions = new PermissionStatus(
+            INodeWithAdditionalFields.PermissionStatusFormat.getUser(permission),
+            INodeWithAdditionalFields.PermissionStatusFormat.getGroup(permission),
+            new FsPermission(INodeWithAdditionalFields.PermissionStatusFormat.getMode(permission)));
+        
+        String holder = op.getHolder();
+        String clientMachine = op.getClientMachine();
+        EnumSet<CreateFlag> flag = EnumSet.noneOf(CreateFlag.class);;
+        for (int i = 0; i < op.getFlagCount(); ++i) {
+            if (op.getFlag(i) == Operation.Flag.CREATE) {
+                flag.add(CreateFlag.CREATE);
+            }
+        }
+        boolean createParent = op.getCreateParent();
+        short replication = (short) op.getReplication();
+        long blockSize = op.getBlockSize();
+        CryptoProtocolVersion[] supportedVersions = new CryptoProtocolVersion[op.getSupportedVersionsCount()];
+        for (int i = 0; i < op.getSupportedVersionsCount(); ++i) {
+            CryptoProtocol cp = op.getSupportedVersions(i);
+            if (cp.getVersion() == 0x01)
+                supportedVersions[i] = CryptoProtocolVersion.UNKNOWN;
+            else
+                supportedVersions[i] = CryptoProtocolVersion.ENCRYPTION_ZONES;
+            supportedVersions[i].setUnknownValue(cp.getUnknownValue());
+        }
+        String ecPolicyName = op.getEcPolicyName();
+        boolean logRetryCache = op.getLogRetryCache();
+
+        FSNamesystem fsn = FSDirectory.getInstance().getFSNamesystem();
+        return fsn.startFile(src, permissions, holder, clientMachine, flag, createParent,
+            replication, blockSize, supportedVersions, ecPolicyName, logRetryCache);
     }
 
     @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -2517,15 +2517,15 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
           throw e;
         }
       }
-    }
-
-    try {
-      status = startFileInt(src, permissions, holder, clientMachine, flag,
-          createParent, replication, blockSize, supportedVersions, ecPolicyName,
-          logRetryCache);
-    } catch (AccessControlException e) {
-      logAuditEvent(false, "create", src);
-      throw e;
+    } else {
+      try {
+        status = startFileInt(src, permissions, holder, clientMachine, flag,
+            createParent, replication, blockSize, supportedVersions, ecPolicyName,
+            logRetryCache);
+      } catch (AccessControlException e) {
+        logAuditEvent(false, "create", src);
+        throw e;
+      }
     }
     logAuditEvent(true, "create", src, status);
     return status;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/fsimage.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/fsimage.proto
@@ -85,6 +85,41 @@ message MountPartition {
   optional string newUri = 3;  
 }
 
+message CryptoProtocol {
+  optional string description = 1;
+  optional int32 version = 2;
+  optional int32 unknownValue = 3;
+}
+
+message Operation {
+
+  enum Flag {
+    CREATE = 0x01;
+    OVERWRITE = 0x02;
+    APPEND = 0x04;
+    SYNC_BLOCK = 0x08;
+    LAZY_PERSIST = 0x10;
+    NEW_BLOCK = 0x20;
+    NO_LOCAL_WRITE = 0x40;
+    SHOULD_REPLICATE = 0x80;
+    IGNORE_CLIENT_LOCALITY = 0x100;
+  }
+
+  message Create {
+    optional string src = 1;
+    optional int64 permissions = 2;
+    optional string holder = 3;
+    optional string clientMachine = 4;
+    optional bool createParent = 5;
+    optional int32 replication = 6;
+    optional int64 blockSize = 7;
+    optional string ecPolicyName = 8;
+    optional bool logRetryCache = 9;
+    repeated Flag flag = 10;
+    repeated CryptoProtocol supportedVersions = 11;
+  }
+}
+
 /**
  * Permission is serialized as a 64-bit long. [0:24):[25:48):[48:64) (in Big Endian).
  * The first and the second parts are the string ids of the user and


### PR DESCRIPTION
- [x] admin op - repartition mount table --> cache mount point changes in the old destination. [PR Merged](https://github.com/DSLAM-UMD/FileScale/commit/8c624dd130e7b9b7c592420f3a56bf9ac1213915)
- [x] RPC: re-route request from the wrong (old) destination to the right place (new destination). #288